### PR TITLE
Fix input path on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +338,7 @@ dependencies = [
 name = "html2pdf"
 version = "0.4.0"
 dependencies = [
+ "dunce",
  "failure",
  "headless_chrome",
  "humantime 2.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "1.0"
 
 log = "0.4"
 pretty_env_logger = "0.4"
+dunce = "1.0.2"
 
 [dev-dependencies]
 test-case = "1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl From<failure::Error> for Error {
 
 /// Run HTML to PDF with headless_chrome
 pub fn run(opt: CliOptions) -> Result<(), Error> {
-    let input = fs::canonicalize(opt.input())?;
+    let input = dunce::canonicalize(opt.input())?;
     let output = if let Some(out) = opt.output() {
         out.clone()
     } else {


### PR DESCRIPTION
This pull request is related to issue #5 and addresses UNC Windows paths.

Swaps `fs::canonicalize` for `dunce::canonicalize` which handles UNC paths. This only affects Windows and the package is effectively the `fs` version on *nix, according to the docs.

[Dunce crate](https://lib.rs/crates/dunce)

I tested this manually on Windows and Windows Linux Subsystem.