### PR TITLE
Add disable-sandbox option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,28 @@ USAGE:
     html2pdf [FLAGS] [OPTIONS] <input>
 
 FLAGS:
-        --background    Allow print background
-    -h, --help          Prints help information
-        --landscape     Use landscape mode
-    -V, --version       Prints version information
+        --background       Allow print background
+    -h, --help             Prints help information
+        --landscape        Use landscape mode
+        --disable-sandbox  Disable Chrome sandbox. Not recommended, unless running on docker
+
+    -V, --version          Prints version information
 
 OPTIONS:
-        --footer <footer>    HTML template for the print footer. Should use the same format as the headerTemplate
-        --header <header>    HTML template for the print header. Should be valid HTML markup with following classes used
-                             to inject printing values into them: date for formatted print date, title for document
-                             title, url for document location, pageNumber for current page number, totalPages for total
-                             pages in the document. For example, `<span class=title></span>` would generate span
-                             containing the title
-        --margin <margin>    Margin in inches You can define margin like this: '0.4' the value is applied for all side,
-                             '0.4 0.4' : first value is applied for top and bottom, second for left and right, '0.4 0.4
-                             0.4 0.4' : first value is applied for top then, right, then bottom, and last for left
-    -o, --output <output>    Output file. By default, just change the input extension to PDF
-        --paper <paper>      Paper size. Supported values: A4, Letter, A3, Tabloid, A2, A1, A0, A5, A6
-        --range <range>      Paper ranges to print, e.g. '1-5, 8, 11-13'
-        --scale <scale>      Scale, default to 1.0
-        --wait <wait>        Time to wait in ms before printing. Examples: 150ms, 10s
+        --footer <footer>  HTML template for the print footer. Should use the same format as the headerTemplate
+        --header <header>  HTML template for the print header. Should be valid HTML markup with following classes used
+                           to inject printing values into them: date for formatted print date, title for document
+                           title, url for document location, pageNumber for current page number, totalPages for total
+                           pages in the document. For example, `<span class=title></span>` would generate span
+                           containing the title
+        --margin <margin>  Margin in inches You can define margin like this: '0.4' the value is applied for all side,
+                                  '0.4 0.4' : first value is applied for top and bottom, second for left and right, '0.4 0.4
+                                  0.4 0.4' : first value is applied for top then, right, then bottom, and last for left
+    -o, --output <output>  Output file. By default, just change the input extension to PDF
+        --paper <paper>    Paper size. Supported values: A4, Letter, A3, Tabloid, A2, A1, A0, A5, A6
+        --range <range>    Paper ranges to print, e.g. '1-5, 8, 11-13'
+        --scale <scale>    Scale, default to 1.0
+        --wait <wait>      Time to wait in ms before printing. Examples: 150ms, 10s
 
 ARGS:
     <input>    Input HTML file

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use clap::Parser;
 use headless_chrome::types::PrintToPdfOptions;
+use headless_chrome::LaunchOptions;
 use humantime::parse_duration;
 
 use crate::Error;
@@ -70,6 +71,11 @@ pub struct Options {
     /// '0.4 0.4 0.4 0.4' : first value is applied for top then, right, then bottom, and last for left
     #[clap(long)]
     pub margin: Option<Margin>,
+
+    /// Disable Chrome sandbox
+    /// Not recommended, unless running on docker
+    #[clap(long)]
+    pub disable_sandbox: bool,
 }
 
 impl Options {
@@ -138,6 +144,12 @@ impl Options {
     pub fn range(&self) -> Option<&String> {
         self.range.as_ref()
     }
+
+    /// Get a reference to the cli options's sandbox.
+    #[must_use]
+    pub fn disable_sandbox(&self) -> bool {
+        self.disable_sandbox
+    }
 }
 
 impl From<&Options> for PrintToPdfOptions {
@@ -159,6 +171,15 @@ impl From<&Options> for PrintToPdfOptions {
             footer_template: opt.footer().cloned(),
             prefer_css_page_size: None,
             transfer_mode: None,
+        }
+    }
+}
+
+impl From<&Options> for LaunchOptions<'_> {
+    fn from(opt: &Options) -> Self {
+        LaunchOptions {
+            sandbox: !opt.disable_sandbox(),
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
To run on Docker, it's necessary to disable Chrome sandbox option, so here's a PR that exposes this option to both the API and the command line.

See https://github.com/rust-headless-chrome/rust-headless-chrome/pull/406