### PR TITLE
Fix the bug with a waiting time of more than 30 seconds

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,6 +179,7 @@ impl From<&Options> for LaunchOptions<'_> {
     fn from(opt: &Options) -> Self {
         LaunchOptions {
             sandbox: !opt.disable_sandbox(),
+            idle_browser_timeout: opt.wait().unwrap_or(Duration::from_secs(30)),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Hello, thank you very much for opening up this project. Recently, I encountered an issue while using it. When the waiting is greater than 30s(for example 40s), converting HTML to PDF will fail. I found the cause in [rust-headless-chrome](https://github.com/rust-headless-chrome/rust-headless-chrome/blob/d53405bf799c3d2f74ecd8c4daa656b194397d2e/src/browser/process.rs#L159) and fixed this bug.