### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.7.1](https://github.com/ilaborie/html2pdf/compare/v0.7.0...v0.7.1) - 2024-03-12
+
+### Other
+- :arrow_up: Bump actions/checkout from 1 to 4
+- :construction_worker: Configure dependabot
+- :construction_worker: Add Release-plz
+- :arrow_up: Bump dependencies
+- Fix the bug that failed to export with a waiting time of more than 30 seconds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "html2pdf"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2pdf"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Igor Laborie <ilaborie@gmail.com>"]
 description = "Convert HTML to PDF using a Headless Chrome browser"


### PR DESCRIPTION
## 🤖 New release
* `html2pdf`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.1](https://github.com/ilaborie/html2pdf/compare/v0.7.0...v0.7.1) - 2024-03-12

### Other
- :arrow_up: Bump actions/checkout from 1 to 4
- :construction_worker: Configure dependabot
- :construction_worker: Add Release-plz
- :arrow_up: Bump dependencies
- Fix the bug that failed to export with a waiting time of more than 30 seconds.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).