### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/ilaborie/html2pdf/compare/v0.7.1...v0.8.0) - 2024-11-24
+
+### Added
+
+- cleanup dependencies
+
 ## [0.7.1](https://github.com/ilaborie/html2pdf/compare/v0.7.0...v0.7.1) - 2024-03-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "html2pdf"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2pdf"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 authors = ["Igor Laborie <ilaborie@gmail.com>"]
 description = "Convert HTML to PDF using a Headless Chrome browser"


### PR DESCRIPTION
## 🤖 New release
* `html2pdf`: 0.7.1 -> 0.8.0 (⚠️ API breaking changes)

### ⚠️ `html2pdf` breaking changes

```
--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant Error::InvalidPaperSize in /tmp/.tmpsQZZYM/html2pdf/src/lib.rs:34
  variant Error::InvalidMarginDefinition in /tmp/.tmpsQZZYM/html2pdf/src/lib.rs:42
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/ilaborie/html2pdf/compare/v0.7.1...v0.8.0) - 2024-11-24

### Added

- cleanup dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).