### PR TITLE
feat: add version flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,7 @@ use crate::Error;
 
 /// Generate a PDF from a local HTML file using a headless chrome
 #[derive(Debug, Parser)]
+#[clap(version)]
 pub struct Options {
     /// Input HTML file.
     pub input: PathBuf,


### PR DESCRIPTION
- The `--version` flag is useful for testing in package managers such as [nixpkgs](https://github.com/NixOS/nixpkgs/blob/d3dc44f8fa73a910bf50629f5dd2e82e8b4a2b68/doc/stdenv/passthru.chapter.md?plain=1#L75-L92).
- It is unclear whether this feature was introduced in an earlier version (e.g., as [mentioned in the 0.4.0 README](https://github.com/ilaborie/html2pdf/blob/eafa6b8d69b6dd8d3284b9769992cf24adba81a0/README.md?plain=1#L45)) or if this is the first time it has been added.


## Before

```console
> ./target/debug/html2pdf --version
error: unexpected argument '--version' found

  tip: to pass '--version' as a value, use '-- --version'

Usage: html2pdf [OPTIONS] <INPUT>

For more information, try '--help'.

> ./target/debug/html2pdf --help
Generate a PDF from a local HTML file using a headless chrome

Usage: html2pdf [OPTIONS] <INPUT>

Arguments:
  <INPUT>  Input HTML file

Options:
  -o, --output <OUTPUT>  Output file. By default, just change the input extension to PDF
      --landscape        Use landscape mode
      --background       Allow print background
      --wait <WAIT>      Time to wait in ms before printing. Examples: 150ms, 10s
      --header <HEADER>  HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them: date for formatted print date, title for document title, url for document location, pageNumber for current page number, totalPages for total pages in the document. For example, `<span class=title></span>` would generate span containing the title
      --footer <FOOTER>  HTML template for the print footer. Should use the same format as the headerTemplate
      --paper <PAPER>    Paper size. Supported values: A4, Letter, A3, Tabloid, A2, A1, A0, A5, A6
      --scale <SCALE>    Scale, default to 1.0
      --range <RANGE>    Paper ranges to print, e.g. '1-5, 8, 11-13'
      --margin <MARGIN>  Margin in inches You can define margin like this: '0.4' the value is applied for all side, '0.4 0.4' : first value is applied for top and bottom, second for left and right, '0.4 0.4 0.4 0.4' : first value is applied for top then, right, then bottom, and last for left
      --disable-sandbox  Disable Chrome sandbox Not recommended, unless running on docker
  -h, --help             Print help
```

## After

```console
> ./target/debug/html2pdf --version
html2pdf 0.8.2

> ./target/debug/html2pdf --help
Generate a PDF from a local HTML file using a headless chrome

Usage: html2pdf [OPTIONS] <INPUT>

Arguments:
  <INPUT>  Input HTML file

Options:
  -o, --output <OUTPUT>  Output file. By default, just change the input extension to PDF
      --landscape        Use landscape mode
      --background       Allow print background
      --wait <WAIT>      Time to wait in ms before printing. Examples: 150ms, 10s
      --header <HEADER>  HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them: date for formatted print date, title for document title, url for document location, pageNumber for current page number, totalPages for total pages in the document. For example, `<span class=title></span>` would generate span containing the title
      --footer <FOOTER>  HTML template for the print footer. Should use the same format as the headerTemplate
      --paper <PAPER>    Paper size. Supported values: A4, Letter, A3, Tabloid, A2, A1, A0, A5, A6
      --scale <SCALE>    Scale, default to 1.0
      --range <RANGE>    Paper ranges to print, e.g. '1-5, 8, 11-13'
      --margin <MARGIN>  Margin in inches You can define margin like this: '0.4' the value is applied for all side, '0.4 0.4' : first value is applied for top and bottom, second for left and right, '0.4 0.4 0.4 0.4' : first value is applied for top then, right, then bottom, and last for left
      --disable-sandbox  Disable Chrome sandbox Not recommended, unless running on docker
  -h, --help             Print help
  -V, --version          Print version
```
